### PR TITLE
Store configurations in individual repositories

### DIFF
--- a/src/cmd/poule/serve.go
+++ b/src/cmd/poule/serve.go
@@ -36,15 +36,21 @@ func doServeCommand(c *cli.Context) {
 	if err := yaml.Unmarshal(b, &serveConfig); err != nil {
 		log.Fatalf("Failed to read config file %q: %v", cfgPath, err)
 	}
-
 	overrides := configuration.FromGlobalFlags(c)
 	overrideConfig(&serveConfig.Config, overrides)
 
+	// Create the server.
 	s, err := server.NewServer(&serveConfig)
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	// Initialize repositories specific configuration from GitHub.
+	if err := s.FetchRepositoriesConfigs(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Start the long-running job.
 	if err := s.Run(); err != nil {
 		log.Fatal(err)
 	}

--- a/src/poule/configuration/constants.go
+++ b/src/poule/configuration/constants.go
@@ -11,4 +11,7 @@ const (
 	// PouleToken is injected as an HTML comment in the body of all messages
 	// posted by the tool itself.
 	PouleToken = "AUTOMATED:POULE"
+
+	// PouleConfigurationFile is the name of the special file at the root of the repository.
+	PouleConfigurationFile = "poule.yml"
 )

--- a/src/poule/configuration/server.go
+++ b/src/poule/configuration/server.go
@@ -2,24 +2,21 @@ package configuration
 
 // Server is the configuration object for the server mode.
 type Server struct {
-	Config    `yaml:",inline"`
-	NSQConfig `yaml:",inline"`
-	Actions   []Action `yaml:"configuration"`
+	Config      `yaml:",inline"`
+	LookupdAddr string `yaml:"nsq_lookupd"`
+	Channel     string `yaml:"nsq_channel"`
+
+	// Repositories maps GitHub repositories full names their corresponding
+	// NSQ topic.
+	Repositories map[string]string `yaml:"repositories"`
+
+	// CommonActions defines the triggers and operations which apply to every configured repository.
+	CommonActions []Action `yaml:"common_configuration"`
 }
 
-type NSQConfig struct {
-	LookupdAddr string   `yaml:"nsq_lookupd"`
-	Channel     string   `yaml:"nsq_channel"`
-	Topics      []string `yaml:"nsq_topics"`
-}
-
-// Action is the definition of an action: it descrbibes operations to apply on a set of
-// repositories when any of the associated triggers are met.
+// Action is the definition of an action: it descrbibes operations to apply when any of the
+// associated triggers are met.
 type Action struct {
-	// Repositories is the list of repositories full names (e.g., "docker/dokcer") that the action
-	// applies to.
-	Repositories StringSlice `yaml:"repositories"`
-
 	// Triggers is the collection of GitHub events that should trigger the action. The keys must be
 	// valid GitHub event types (e.g., "pull_request"), and the value must be a list of alid values
 	// for the action field of the GitHub paylost (e.g., "created").

--- a/src/poule/gh/github.go
+++ b/src/poule/gh/github.go
@@ -34,6 +34,7 @@ type IssuesService interface {
 type PullRequestsService interface {
 	// Pull requests API.
 	List(owner string, repo string, opt *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error)
+	ListFiles(owner string, repo string, number int, opt *github.ListOptions) ([]*github.CommitFile, *github.Response, error)
 
 	// Commits API.
 	ListCommits(owner string, repo string, number int, opt *github.ListOptions) ([]*github.RepositoryCommit, *github.Response, error)

--- a/src/poule/operations/catalog/poule-updater.go
+++ b/src/poule/operations/catalog/poule-updater.go
@@ -1,0 +1,86 @@
+package catalog
+
+import (
+	"errors"
+	"fmt"
+
+	"poule/configuration"
+	"poule/gh"
+	"poule/operations"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/google/go-github/github"
+	"github.com/urfave/cli"
+)
+
+// OK, global state is terrible, but I like to think of `pouleUpdaterOperation` as an exception
+// rather than the norm. If more of such operations need to exist in the future, we may want to
+// create a special kind of "core operations" which have privileged access to the configuration.
+var PouleUpdateCallback func(repository string) error
+
+func init() {
+	registerOperation(&pouleUpdaterDescriptor{})
+}
+
+type pouleUpdaterDescriptor struct{}
+
+func (d *pouleUpdaterDescriptor) CommandLineDescription() CommandLineDescription {
+	return CommandLineDescription{
+		Name:        "poule-updater",
+		Description: "Update the poule configuration for the specified repository",
+	}
+}
+
+func (d *pouleUpdaterDescriptor) OperationFromCli(c *cli.Context) (operations.Operation, error) {
+	return nil, fmt.Errorf("The poule-updater operation cannot be created from the command line")
+}
+
+func (d *pouleUpdaterDescriptor) OperationFromConfig(c operations.Configuration) (operations.Operation, error) {
+	return &pouleUpdaterOperation{}, nil
+}
+
+type pouleUpdaterOperation struct{}
+
+func (o *pouleUpdaterOperation) Accepts() operations.AcceptedType {
+	return operations.PullRequests
+}
+
+func (o *pouleUpdaterOperation) Apply(c *operations.Context, item gh.Item, userData interface{}) error {
+	if PouleUpdateCallback == nil {
+		return errors.New("poule configuration update callback is nil")
+	}
+	return PouleUpdateCallback(item.Repository())
+}
+
+func (o *pouleUpdaterOperation) Describe(c *operations.Context, item gh.Item, userData interface{}) string {
+	return fmt.Sprintf("updating configuration")
+}
+
+func (o *pouleUpdaterOperation) Filter(c *operations.Context, item gh.Item) (operations.FilterResult, interface{}, error) {
+	// We're looking for merge pull request which modify the poule configuration.
+	pr := item.PullRequest
+	if pr.Merged != nil && *pr.Merged == false {
+		logrus.Debug("rejecting unmerged pull request")
+		return operations.Reject, nil, nil
+	}
+
+	// List all files modified by the pull requests, and look for our special configuration file.
+	commitFiles, _, err := c.Client.PullRequests().ListFiles(c.Username, c.Repository, item.Number(), nil)
+	if err != nil {
+		return operations.Reject, nil, err
+	}
+	for _, commitFile := range commitFiles {
+		if *commitFile.Filename == configuration.PouleConfigurationFile {
+			return operations.Accept, nil, nil
+		}
+	}
+	return operations.Reject, nil, nil
+}
+
+func (o *pouleUpdaterOperation) IssueListOptions(c *operations.Context) *github.IssueListByRepoOptions {
+	return nil
+}
+
+func (o *pouleUpdaterOperation) PullRequestListOptions(c *operations.Context) *github.PullRequestListOptions {
+	return nil
+}

--- a/src/poule/operations/catalog/poule-updater_test.go
+++ b/src/poule/operations/catalog/poule-updater_test.go
@@ -1,0 +1,63 @@
+package catalog
+
+import (
+	"testing"
+
+	"poule/configuration"
+	"poule/operations"
+	"poule/test"
+
+	"github.com/google/go-github/github"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockUpdater struct {
+	mock.Mock
+}
+
+func (m *mockUpdater) UpdateCallback(repository string) error {
+	return m.Called(repository).Error(0)
+}
+
+func TestPouleUpdater(t *testing.T) {
+	clt, ctx := makeContext()
+
+	// Create test pull request and related issue object.
+	item := test.NewPullRequestBuilder(test.IssueNumber).
+		Merged(true).
+		HeadBranch(ctx.Username, ctx.Repository, "head", test.CommitSHA[0]).
+		BaseBranch(ctx.Username, ctx.Repository, "master", test.CommitSHA[1]).Item()
+
+	// Create a mock for the poule update callback.
+	m := &mockUpdater{}
+	m.On("UpdateCallback", item.Repository()).Return(nil)
+	PouleUpdateCallback = m.UpdateCallback
+
+	// Set up the mock objects.
+	commitFiles := []*github.CommitFile{
+		&github.CommitFile{
+			Filename: test.MakeString("Dockerfile"),
+		},
+		&github.CommitFile{
+			Filename: test.MakeString(configuration.PouleConfigurationFile),
+		},
+	}
+	clt.MockPullRequests.
+		On("ListFiles", ctx.Username, ctx.Repository, test.IssueNumber, mock.AnythingOfType("*github.ListOptions")).
+		Return(commitFiles, nil, nil)
+
+	// Call into the operation.
+	op := &pouleUpdaterOperation{}
+	res, userData, err := op.Filter(ctx, item)
+	if err != nil {
+		t.Fatalf("Filter returned unexpected error %v", err)
+	}
+	if res != operations.Accept {
+		t.Fatalf("Filter returned unexpected result %v", res)
+	}
+	if err := op.Apply(ctx, item, userData); err != nil {
+		t.Fatalf("Apply returned unexpected error %v", err)
+	}
+	m.AssertExpectations(t)
+	test.AssertExpectations(clt, t)
+}

--- a/src/poule/operations/catalog/version-milestone.go
+++ b/src/poule/operations/catalog/version-milestone.go
@@ -54,7 +54,7 @@ func (o *versionMilestoneOperation) Apply(c *operations.Context, item gh.Item, u
 }
 
 func (o *versionMilestoneOperation) Describe(c *operations.Context, item gh.Item, userData interface{}) string {
-	return fmt.Sprintf("adding pull reques to milestone %d (%q)", *userData.(*github.Milestone).Number, *userData.(*github.Milestone).Title)
+	return fmt.Sprintf("adding pull request to milestone %d (%q)", *userData.(*github.Milestone).Number, *userData.(*github.Milestone).Title)
 }
 
 func (o *versionMilestoneOperation) Filter(c *operations.Context, item gh.Item) (operations.FilterResult, interface{}, error) {

--- a/src/poule/test/mocks/PullRequestsService.go
+++ b/src/poule/test/mocks/PullRequestsService.go
@@ -72,3 +72,35 @@ func (_m *PullRequestsService) ListCommits(owner string, repo string, number int
 
 	return r0, r1, r2
 }
+
+// ListFiles provides a mock function with given fields: owner, repo, number, opt
+func (_m *PullRequestsService) ListFiles(owner string, repo string, number int, opt *github.ListOptions) ([]*github.CommitFile, *github.Response, error) {
+	ret := _m.Called(owner, repo, number, opt)
+
+	var r0 []*github.CommitFile
+	if rf, ok := ret.Get(0).(func(string, string, int, *github.ListOptions) []*github.CommitFile); ok {
+		r0 = rf(owner, repo, number, opt)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*github.CommitFile)
+		}
+	}
+
+	var r1 *github.Response
+	if rf, ok := ret.Get(1).(func(string, string, int, *github.ListOptions) *github.Response); ok {
+		r1 = rf(owner, repo, number, opt)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*github.Response)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(string, string, int, *github.ListOptions) error); ok {
+		r2 = rf(owner, repo, number, opt)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}


### PR DESCRIPTION
Entirely review the format of the configuration, so that the main configuration only provides the list of repositories to monitor and the general scaffolding (e.g., GitHub tokens, NSQ configuration).

Configuration for the individual repositories now need to live in the special `poule.yml` file at the root of the repositories themselves. In other words, we won't have to update a centralized configuration, unless if we want to add a new repository to watch for.

Thanks @crosbymichael for the suggestion!

Fixes #9.