### PR TITLE
Ignore failure to remove label in `dco-check`

### DIFF
--- a/src/poule/operations/catalog/dco-check.go
+++ b/src/poule/operations/catalog/dco-check.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 
@@ -219,7 +220,11 @@ func toggleDCOLabel(c *operations.Context, pr *github.PullRequest, enable bool, 
 		}
 	} else {
 		// Remove unsigned label from issue.
-		if _, err := c.Client.Issues().RemoveLabelForIssue(c.Username, c.Repository, *pr.Number, label); err != nil {
+		if resp, err := c.Client.Issues().RemoveLabelForIssue(c.Username, c.Repository, *pr.Number, label); err != nil {
+			// Ignore 404 errors.
+			if resp.StatusCode == http.StatusNotFound {
+				return nil
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
We're getting a lot of errors in the log as `dco-check` always attempts to remove the `dco/no` label, even when absent. This produces a 404 in the GitHub API, and is treated by the operation as an error (hence, the message gets requeued in NSQ).

Safely ignore 404 when trying to remove the `dco/no` label.

Signed-off-by: Arnaud Porterie (icecrime) <arnaud.porterie@docker.com>