### PR TITLE
Make `dco-check` update the pull request status

### DIFF
--- a/src/poule/gh/github.go
+++ b/src/poule/gh/github.go
@@ -43,5 +43,6 @@ type PullRequestsService interface {
 //go:generate mockery -name=RepositoriesService -output ../test/mocks
 type RepositoriesService interface {
 	// Statuses API.
+	CreateStatus(owner, repo, ref string, sts *github.RepoStatus) (*github.RepoStatus, *github.Response, error)
 	ListStatuses(owner, repo, ref string, opt *github.ListOptions) ([]*github.RepoStatus, *github.Response, error)
 }

--- a/src/poule/operations/catalog/poule-updater_test.go
+++ b/src/poule/operations/catalog/poule-updater_test.go
@@ -36,10 +36,10 @@ func TestPouleUpdater(t *testing.T) {
 	// Set up the mock objects.
 	commitFiles := []*github.CommitFile{
 		&github.CommitFile{
-			Filename: test.MakeString("Dockerfile"),
+			Filename: github.String("Dockerfile"),
 		},
 		&github.CommitFile{
-			Filename: test.MakeString(configuration.PouleConfigurationFile),
+			Filename: github.String(configuration.PouleConfigurationFile),
 		},
 	}
 	clt.MockPullRequests.

--- a/src/poule/operations/catalog/version-label_test.go
+++ b/src/poule/operations/catalog/version-label_test.go
@@ -34,7 +34,7 @@ func TestVersionLabel(t *testing.T) {
 		issue := test.NewIssueBuilder(test.IssueNumber).Body(body).Item()
 		clt.MockIssues.
 			On("AddLabelsToIssue", ctx.Username, ctx.Repository, test.IssueNumber, []string{expected}).
-			Return([]*github.Label{&github.Label{Name: test.MakeString(expected)}}, nil, nil)
+			Return([]*github.Label{&github.Label{Name: github.String(expected)}}, nil, nil)
 
 		res, userData, err := operation.Filter(ctx, issue)
 		if err != nil {

--- a/src/poule/operations/catalog/version-milestone_test.go
+++ b/src/poule/operations/catalog/version-milestone_test.go
@@ -28,19 +28,19 @@ func TestAutoMilestone(t *testing.T) {
 	// Mock the milestones API.
 	milestones := []*github.Milestone{
 		&github.Milestone{
-			Number: test.MakeInt(1),
-			Title:  test.MakeString("old-version"),
-			State:  test.MakeString("closed"),
+			Number: github.Int(1),
+			Title:  github.String("old-version"),
+			State:  github.String("closed"),
 		},
 		&github.Milestone{
-			Number: test.MakeInt(2),
-			Title:  test.MakeString("other-version"),
-			State:  test.MakeString("open"),
+			Number: github.Int(2),
+			Title:  github.String("other-version"),
+			State:  github.String("open"),
 		},
 		&github.Milestone{
-			Number: test.MakeInt(3),
-			Title:  test.MakeString("test-version"),
-			State:  test.MakeString("open"),
+			Number: github.Int(3),
+			Title:  github.String("test-version"),
+			State:  github.String("open"),
 		},
 	}
 	clt.MockIssues.On("ListMilestones", ctx.Username, ctx.Repository, mock.AnythingOfType("*github.MilestoneListOptions")).

--- a/src/poule/test/github.go
+++ b/src/poule/test/github.go
@@ -28,7 +28,7 @@ func (t *TestClient) Repositories() gh.RepositoriesService {
 
 func MakeLabel(name string) github.Label {
 	return github.Label{
-		Name: MakeString(name),
+		Name: github.String(name),
 	}
 }
 

--- a/src/poule/test/issue.go
+++ b/src/poule/test/issue.go
@@ -9,7 +9,7 @@ import (
 func NewIssueBuilder(number int) *IssueBuilder {
 	return &IssueBuilder{
 		Value: &github.Issue{
-			Number: MakeInt(number),
+			Number: github.Int(number),
 		},
 	}
 }
@@ -23,7 +23,7 @@ func (p *IssueBuilder) Item() gh.Item {
 }
 
 func (p *IssueBuilder) Body(body string) *IssueBuilder {
-	p.Value.Body = MakeString(body)
+	p.Value.Body = github.String(body)
 	return p
 }
 
@@ -35,6 +35,6 @@ func (p *IssueBuilder) Labels(names []string) *IssueBuilder {
 }
 
 func (p *IssueBuilder) Number(number int) *IssueBuilder {
-	p.Value.Number = MakeInt(number)
+	p.Value.Number = github.Int(number)
 	return p
 }

--- a/src/poule/test/mocks/RepositoriesService.go
+++ b/src/poule/test/mocks/RepositoriesService.go
@@ -9,6 +9,38 @@ type RepositoriesService struct {
 	mock.Mock
 }
 
+// CreateStatus provides a mock function with given fields: owner, repo, ref, sts
+func (_m *RepositoriesService) CreateStatus(owner string, repo string, ref string, sts *github.RepoStatus) (*github.RepoStatus, *github.Response, error) {
+	ret := _m.Called(owner, repo, ref, sts)
+
+	var r0 *github.RepoStatus
+	if rf, ok := ret.Get(0).(func(string, string, string, *github.RepoStatus) *github.RepoStatus); ok {
+		r0 = rf(owner, repo, ref, sts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*github.RepoStatus)
+		}
+	}
+
+	var r1 *github.Response
+	if rf, ok := ret.Get(1).(func(string, string, string, *github.RepoStatus) *github.Response); ok {
+		r1 = rf(owner, repo, ref, sts)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*github.Response)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(string, string, string, *github.RepoStatus) error); ok {
+		r2 = rf(owner, repo, ref, sts)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // ListStatuses provides a mock function with given fields: owner, repo, ref, opt
 func (_m *RepositoriesService) ListStatuses(owner string, repo string, ref string, opt *github.ListOptions) ([]*github.RepoStatus, *github.Response, error) {
 	ret := _m.Called(owner, repo, ref, opt)

--- a/src/poule/test/pullrequest.go
+++ b/src/poule/test/pullrequest.go
@@ -10,7 +10,7 @@ import (
 func NewPullRequestBuilder(number int) *PullRequestBuilder {
 	return &PullRequestBuilder{
 		Value: &github.PullRequest{
-			Number: MakeInt(number),
+			Number: github.Int(number),
 		},
 	}
 }
@@ -25,61 +25,61 @@ func (p *PullRequestBuilder) Item() gh.Item {
 
 func (p *PullRequestBuilder) BaseBranch(username, repository, ref string, SHA string) *PullRequestBuilder {
 	p.Value.Base = &github.PullRequestBranch{
-		Ref: MakeString(ref),
+		Ref: github.String(ref),
 		Repo: &github.Repository{
-			FullName: MakeString(username + "/" + repository),
-			Name:     MakeString(repository),
+			FullName: github.String(username + "/" + repository),
+			Name:     github.String(repository),
 			Owner: &github.User{
-				Login: MakeString(username),
+				Login: github.String(username),
 			},
 		},
-		SHA: MakeString(SHA),
+		SHA: github.String(SHA),
 	}
 	return p
 }
 
 func (p *PullRequestBuilder) Body(body string) *PullRequestBuilder {
-	p.Value.Body = MakeString(body)
+	p.Value.Body = github.String(body)
 	return p
 }
 
 func (p *PullRequestBuilder) Commits(commits int) *PullRequestBuilder {
-	p.Value.Commits = MakeInt(commits)
+	p.Value.Commits = github.Int(commits)
 	return p
 }
 
 func (p *PullRequestBuilder) HeadBranch(username, repository, ref string, SHA string) *PullRequestBuilder {
 	p.Value.Head = &github.PullRequestBranch{
-		Ref: MakeString(ref),
+		Ref: github.String(ref),
 		Repo: &github.Repository{
-			FullName: MakeString(username + "/" + repository),
-			Name:     MakeString(repository),
+			FullName: github.String(username + "/" + repository),
+			Name:     github.String(repository),
 			Owner: &github.User{
-				Login: MakeString(username),
+				Login: github.String(username),
 			},
-			SSHURL: MakeString(fmt.Sprintf("ssh@%s", repository)),
+			SSHURL: github.String(fmt.Sprintf("ssh@%s", repository)),
 		},
-		SHA: MakeString(SHA),
+		SHA: github.String(SHA),
 	}
 	return p
 }
 
 func (p *PullRequestBuilder) Merged(merged bool) *PullRequestBuilder {
-	p.Value.Merged = MakeBool(merged)
+	p.Value.Merged = github.Bool(merged)
 	return p
 }
 
 func (p *PullRequestBuilder) Number(number int) *PullRequestBuilder {
-	p.Value.Number = MakeInt(number)
+	p.Value.Number = github.Int(number)
 	return p
 }
 
 func (p *PullRequestBuilder) State(state string) *PullRequestBuilder {
-	p.Value.State = MakeString(state)
+	p.Value.State = github.String(state)
 	return p
 }
 
 func (p *PullRequestBuilder) Title(title string) *PullRequestBuilder {
-	p.Value.Title = MakeString(title)
+	p.Value.Title = github.String(title)
 	return p
 }

--- a/src/poule/test/utils.go
+++ b/src/poule/test/utils.go
@@ -7,21 +7,3 @@ func AssertExpectations(clt *TestClient, t *testing.T) {
 	clt.MockPullRequests.AssertExpectations(t)
 	clt.MockRepositories.AssertExpectations(t)
 }
-
-func MakeBool(value bool) *bool {
-	v := new(bool)
-	*v = value
-	return v
-}
-
-func MakeInt(value int) *int {
-	v := new(int)
-	*v = value
-	return v
-}
-
-func MakeString(value string) *string {
-	v := new(string)
-	*v = value
-	return v
-}


### PR DESCRIPTION
The DCO check operation only adds a label and a comment. This is confusing people who expect a pull request to be marked as failed when a commit is not signed.

Make the DCO check operation create a status on the pull request to indicate success or failure.

Cc @justincormack @vieux FYI.