### PR TITLE
Rename default server configuration

### DIFF
--- a/src/cmd/poule/serve.go
+++ b/src/cmd/poule/serve.go
@@ -17,7 +17,7 @@ var serveCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "config, c",
-			Value: "poule.yaml",
+			Value: "poule-server.yml",
 			Usage: "Poule configuration",
 		},
 	},


### PR DESCRIPTION
There is an inconsistency between server configuration default value being `poule.yaml` and the default repository-local configuration value being `poule.yml`.

Resolve the discrepancy by renaming the default server configuration to `poule-server.yml`.

Signed-off-by: Arnaud Porterie (icecrime) <arnaud.porterie@docker.com>