### PR TITLE
Disable "status" event handling

### DIFF
--- a/src/poule/server/handler.go
+++ b/src/poule/server/handler.go
@@ -80,8 +80,10 @@ func makeGitHubItems(c *configuration.Config, event string, data []byte) ([]gh.I
 		return makeItemsFromIssueEvent(c, data)
 	case "pull_request", "pull_request_review", "pull_request_review_comment":
 		return makeItemsFromPullRequestEvent(c, data)
-	case "status":
-		return makeItemsFromStatusEvent(c, data)
+	// Handling of the "status" event is temporarily disabled: we don't have a use case for it yet
+	// and it's extremely consuming in terms of API limits.
+	//case "status":
+	//	return makeItemsFromStatusEvent(c, data)
 	default:
 		return nil, nil
 	}


### PR DESCRIPTION
There's no use case for the "status" event yet, and this one is consuming in terms of GitHub API calls (it requires searching all pull requests for the matching SHA, and retrieving each individual pull request returned).

Signed-off-by: Arnaud Porterie (icecrime) <arnaud.porterie@docker.com>