### PR TITLE
Fix serve bug executing only the first operation

### DIFF
--- a/src/poule/server/action.go
+++ b/src/poule/server/action.go
@@ -20,7 +20,9 @@ func executeAction(config *configuration.Config, action configuration.Action, it
 		if err != nil {
 			return err
 		}
-		return opRunner.Handle(item)
+		if err := opRunner.Handle(item); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -35,7 +37,9 @@ func executeActionOnAllItems(config *configuration.Config, action configuration.
 		if err != nil {
 			return err
 		}
-		return opRunner.HandleStock()
+		if err := opRunner.HandleStock(); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fix a bug where only the first operation as part of a trigger was executed when running in serve mode.

Signed-off-by: Arnaud Porterie (icecrime) <arnaud.porterie@docker.com>