### PR TITLE
Filter for when a comment matches a regexp `contains:`

### DIFF
--- a/src/poule/runner/runner.go
+++ b/src/poule/runner/runner.go
@@ -144,7 +144,7 @@ func runSingle(c *configuration.Config, op operations.Operation, item gh.Item, f
 	context.Username, context.Repository = c.SplitRepository()
 
 	// Apply global filters to the item.
-	if !filters.Apply(item) {
+	if !filters.Apply(context, item) {
 		return nil
 	}
 


### PR DESCRIPTION
This includes patches from #41 for simplicity.

This adjusts the filtering interface to:

* Allow for matching of comments,  as mentioned
* Propagation of the operations.Context used to build the filter, so it can do lazy fetching.

rationale for #2: we don't want to fetch ALL the comments unless the filter prescribes it, since it'll be excessively expensive for e.g., label matches.

I hope this patch finds you well. I didn't find a good place for testing it, so please advise. I did test it over at erikh/test-repo though.