### PR TITLE
Remove skipping of PRs marked with failing-ci

### DIFF
--- a/src/poule/operations/catalog/rebuild.go
+++ b/src/poule/operations/catalog/rebuild.go
@@ -121,12 +121,6 @@ func (o *prRebuildOperation) Filter(c *operations.Context, item gh.Item) (operat
 		return operations.Reject, nil, errors.Wrapf(err, "failed to retrieve issue #%d", *pr.Number)
 	}
 
-	// Skip all pull requests which are known to fail CI.
-	if gh.HasFailingCILabel(item.Issue.Labels) {
-		logrus.Debugf("rejecting pull request with label %q", configuration.FailingCILabel)
-		return operations.Reject, nil, nil
-	}
-
 	// Search for our trigger label, if specified.
 	if o.Label != "" && !gh.HasLabel(o.Label, item.Issue.Labels) {
 		logrus.Debugf("rejecting pull request without label %q", o.Label)

--- a/src/poule/operations/catalog/rebuild_test.go
+++ b/src/poule/operations/catalog/rebuild_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"poule/configuration"
 	"poule/gh"
 	"poule/operations"
 	"poule/test"
@@ -125,28 +124,6 @@ func TestRebuildAllConfigurations(t *testing.T) {
 	}
 	if err := operation.Apply(ctx, item, userData); err != nil {
 		t.Fatalf("Apply returned unexpected error %v", err)
-	}
-	test.AssertExpectations(clt, t)
-}
-
-func TestRebuildSkipFailing(t *testing.T) {
-	clt, ctx := makeContext()
-	commitSHA := "baddcafe"
-	operation, _ := makeRebuildOperation([]string{"test"}, []string{}, "")
-
-	// Create test pull request and related issue object.
-	issue := test.NewIssueBuilder(test.IssueNumber).Labels([]string{configuration.FailingCILabel}).Value
-	pullr := test.NewPullRequestBuilder(test.IssueNumber).
-		HeadBranch(ctx.Username, ctx.Repository, "head", commitSHA).
-		BaseBranch(ctx.Username, ctx.Repository, "base", test.CommitSHA[0]).Value
-	clt.MockIssues.On("Get", ctx.Username, ctx.Repository, test.IssueNumber).Return(issue, nil, nil)
-
-	// Call into the operation.
-	item := gh.MakePullRequestItem(pullr)
-	if res, _, err := operation.Filter(ctx, item); err != nil {
-		t.Fatalf("Filter returned unexpected error %v", err)
-	} else if res != operations.Reject {
-		t.Fatalf("Filter should reject issue with label %q", test.IssueNumber)
 	}
 	test.AssertExpectations(clt, t)
 }


### PR DESCRIPTION
I was surprised by this behaviour. I guess it's a minor optimization when this operation is being used for a bulk rebuild, but it's quite unexpected when the operation is triggered by a user on a single PR.

Can we remove this condition?