### PR TITLE
Parse version label correctly from both docker info and docker version

### DIFF
--- a/src/poule/operations/catalog/version-label.go
+++ b/src/poule/operations/catalog/version-label.go
@@ -75,7 +75,7 @@ func extractVersionLabels(issue *github.Issue) (bool, string) {
 	if issue.Body == nil {
 		return false, ""
 	}
-	serverVersion := regexp.MustCompile(`Server:\s+Version:\s+(\d+\.\d+\.\d+)(-\w+)?`)
+	serverVersion := regexp.MustCompile(`(?:Server:?)\s+(?:Docker Engine - Community\s+)?(?:Engine:\s+)?(?:Version:\s+)(\d+\.\d+\.\d+)(-\w+)?`)
 	versionSubmatch := serverVersion.FindStringSubmatch(*issue.Body)
 	if len(versionSubmatch) < 3 {
 		return false, ""

--- a/src/poule/operations/catalog/version-label_test.go
+++ b/src/poule/operations/catalog/version-label_test.go
@@ -27,6 +27,8 @@ func TestVersionLabel(t *testing.T) {
 		"version/1.15":        "Server: Version: 1.15.3pouet",
 		"version/17.03":       "Server: Version: 17.03.0-ce",
 		"version/17.04":       "Server: Version: 17.04.0-ce-rc1",
+		"version/18.03":       "Server Version: 18.03.1-ee-1",
+		"version/18.09":       "Server\n Engine:\n Version:\t18.09.0",
 		"version/master":      "Server: Version: 1.2.3-dev",
 		"version/unsupported": "Server: Version: 1.2.3-toto",
 	} {


### PR DESCRIPTION
I noticed that version labelling does not work with 18.03 / 18.09 and when I was looking for it I also noticed that it was only supporting ```docker version``` command output when version is also available on ```docker info``` command output.

Depends on #59